### PR TITLE
fix broken sepainfo import

### DIFF
--- a/src/ibims/com/bankverbindung.py
+++ b/src/ibims/com/bankverbindung.py
@@ -7,7 +7,7 @@ from typing import Optional
 from bo4e.com.com import COM
 from pydantic import constr, field_validator
 
-from ibims.com import SepaInfo
+from ibims.com.sepa_info import SepaInfo
 
 
 class Bankverbindung(COM):


### PR DESCRIPTION
E   ImportError: cannot import name 'SepaInfo' from partially initialized module 'ibims.com' (most likely due to a circular import) (C:\github\powercloud2lynqtech\.tox\dev\Lib\site-packages\ibims\com\__init__.py)
