### PR TITLE
pin version of the bo4e python repo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [ # add all the dependencies from requirements.in here, too
-    "bo4e>=0.6.0,<0.7.0",
+    "bo4e>=0.5.5,<0.6.0",
     "bomf>=0.6.8"
 ]
 dynamic = ["readme", "version"]

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,3 @@
 # any dependency added here should also be added in pyproject.toml
-bo4e>=0.6.0,<0.7.0
+bo4e>=0.5.5,<0.6.0
 bomf>=0.6.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bidict==0.22.1
     # via
     #   bomf
     #   pvframework
-bo4e==0.6.0
+bo4e==0.5.10
     # via
     #   -r requirements.in
     #   bomf


### PR DESCRIPTION
Because BO4E0.6 has every field optional, leads to many issues in P2L repo, therefore, downgrade to BO4E0.5.10 until the solution for customized BO4E is ready implemented