### PR TITLE
add prognosegrundlage to bilanzierung

### DIFF
--- a/src/ibims/bo/bilanzierung.py
+++ b/src/ibims/bo/bilanzierung.py
@@ -38,5 +38,5 @@ class Bilanzierung(Geschaeftsobjekt):
     prognosegrundlage: Optional[Prognosegrundlage] = None
 
     details_prognosegrundlage: Optional[Profiltyp] = None
-      
+
     lastprofile: list[Lastprofil]

--- a/src/ibims/bo/bilanzierung.py
+++ b/src/ibims/bo/bilanzierung.py
@@ -8,6 +8,8 @@ from bo4e.bo.geschaeftsobjekt import Geschaeftsobjekt
 
 from ibims.enum import BoTypErweitert
 from ibims.enum.aggregationsverantwortung import Aggregationsverantwortung
+from ibims.enum.profiltyp import Profiltyp
+from ibims.enum.prognosegrundlage import Prognosegrundlage
 
 
 class Bilanzierung(Geschaeftsobjekt):
@@ -31,3 +33,7 @@ class Bilanzierung(Geschaeftsobjekt):
     bilanzkreis: Optional[str] = None
 
     aggregationsverantwortung: Optional[Aggregationsverantwortung] = None
+
+    prognosegrundlage: Optional[Prognosegrundlage] = None
+
+    details_prognosegrundlage: Optional[Profiltyp] = None


### PR DESCRIPTION
Die beiden Felder "prognosegrundlage" und "details_prognosegrundlage" sind gerade in der Marktlokation und ich würde sie gerne in die Bilanzierung umziehen, damit das konsistent zu der go und c# Implementierung ist.